### PR TITLE
Added timeout to the http options

### DIFF
--- a/cryptsy.js
+++ b/cryptsy.js
@@ -22,6 +22,7 @@ function CryptsyClient(key, secret) {
       uri: 'https://api.cryptsy.com/api',
       agent: false,
       method: 'POST',
+      timeout: 40000,
       headers: {
         "User-Agent": "Mozilla/4.0 (compatible; Cryptsy API node client)",
         "Content-type": "application/x-www-form-urlencoded"


### PR DESCRIPTION
Cryptsy has the tendency to keep a socket open on their end and the http module in node doesn't always notice this or reject it properly. Adding a timeout of 40 seconds should give ample time to receive even the larges (1000 item) lists and cancel the connection with ETIMEOUT.

In case of gekko usage it stops gekko from locking up on i/o requests.
